### PR TITLE
fixes flag for ssh-add

### DIFF
--- a/ssh/foxpass-keygen.py
+++ b/ssh/foxpass-keygen.py
@@ -46,14 +46,14 @@ def main():
 
     email = input('Email address: ')
     password = getpass.getpass()
-    mfa_code = input('Foxpass MFA code:')
+    mfa_code = input('Foxpass MFA code: ')
 
     try:
         add_key_to_foxpass(api_base, email, password, mfa_code, filename)
         print('')
-        print('Don\'t forget to run ssh-add now. The -K adds the key to your keychain so it is loaded on boot:')
+        print('Don\'t forget to run ssh-add now. The --apple-use-keychain flag (OS X only) adds the key to your keychain so it is loaded on boot:')
         print('')
-        print('ssh-add -K {}'.format(filename))
+        print('ssh-add --apple-use-keychain {}'.format(filename))
         print('')
     except Exception as e:
         print('Exception: {}'.format(e))

--- a/ssh/foxpass-keygen.py
+++ b/ssh/foxpass-keygen.py
@@ -51,8 +51,10 @@ def main():
     try:
         add_key_to_foxpass(api_base, email, password, mfa_code, filename)
         print('')
-        print('Don\'t forget to run ssh-add now. The --apple-use-keychain flag (OS X only) adds the key to your keychain so it is loaded on boot:')
+        print('Don\'t forget to run ssh-add now. The -K (macOS Big Sur or prior) OR --apple-use-keychain flag (macOS Monterey and later) adds the key to your keychain so it is loaded on boot:')
         print('')
+        print('ssh-add -K {}'.format(filename))
+        print('OR')
         print('ssh-add --apple-use-keychain {}'.format(filename))
         print('')
     except Exception as e:


### PR DESCRIPTION
## Description of the change
Fixes ssh-add flag for current OSX versions. See explanation here:
https://apple.stackexchange.com/questions/48502/how-can-i-permanently-add-my-ssh-private-key-to-keychain-so-it-is-automatically

## Type of change
- [x] Bug fix
- [ ] New feature

### Testing

- [x] Testing information has been added - test cases checklist and steps followed for testing.
- [x] Testing screenshot(s) attached for more information.

Tested locally by running the script against a local endpoint
![image](https://user-images.githubusercontent.com/7078270/170783382-570ebe16-83a9-4660-9cac-3dce24621c0e.png)


## Security

- [ ] This PR has security related considerations.
